### PR TITLE
Remove empty link entry from Harold Argleston

### DIFF
--- a/content/Charaktere/NPCs/Harold Argleston.md
+++ b/content/Charaktere/NPCs/Harold Argleston.md
@@ -20,5 +20,4 @@ Er verkauft folgende Goldkarten:
 - [[Zauber/Goldkarten/Mythos/Blutflederer|Blutflederer]]
 - [[Zauber/Goldkarten/Tod/Finsterfee|Finsterfee]]
 - [[Zauber/Goldkarten/Feuer/Feuerkatze|Feuerkatze]]
-- [[]] 
-- 
+  


### PR DESCRIPTION
Removed an empty link entry from the NPC's markdown file.